### PR TITLE
add basejump

### DIFF
--- a/samples.json
+++ b/samples.json
@@ -31,7 +31,7 @@
       "start": "npm install && npm run dev"
     },
     {
-      "name": "basejump-next",
+      "name": "@basejump/next",
       "description": "A Next.js starter with personal accounts, teams, permissions and Stripe billing",
       "url": "https://github.com/usebasejump/basejump-next/tree/supabase-bootstrap",
       "start": "npm install && npm run dev"

--- a/samples.json
+++ b/samples.json
@@ -31,7 +31,7 @@
       "start": "npm install && npm run dev"
     },
     {
-      "name": "@basejump/next",
+      "name": "@basejump/nextjs",
       "description": "A Next.js starter with personal accounts, teams, permissions and Stripe billing",
       "url": "https://github.com/usebasejump/basejump-next/tree/supabase-bootstrap",
       "start": "npm install && npm run dev"

--- a/samples.json
+++ b/samples.json
@@ -29,6 +29,12 @@
       "description": "A Next.js RBAC Slack clone starter.",
       "url": "https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone",
       "start": "npm install && npm run dev"
+    },
+    {
+      "name": "basejump",
+      "description": "Personal accounts, teams, permissions and billing with an Optional Nextjs template",
+      "url": "https://github.com/usebasejump/basejump/tree/main",
+      "start": "Consider installing the Basejump Nextjs starter template"
     }
   ]
 }

--- a/samples.json
+++ b/samples.json
@@ -34,7 +34,7 @@
       "name": "basejump-next",
       "description": "A Next.js starter with personal accounts, teams, permissions and Stripe billing",
       "url": "https://github.com/usebasejump/basejump-next/tree/supabase-bootstrap",
-      "start": "Consider installing the Basejump Nextjs starter template"
+      "start": "npm install && npm run dev"
     }
   ]
 }

--- a/samples.json
+++ b/samples.json
@@ -31,9 +31,9 @@
       "start": "npm install && npm run dev"
     },
     {
-      "name": "basejump",
-      "description": "Personal accounts, teams, permissions and billing with an Optional Nextjs template",
-      "url": "https://github.com/usebasejump/basejump/tree/main",
+      "name": "basejump-next",
+      "description": "A Next.js starter with personal accounts, teams, permissions and Stripe billing",
+      "url": "https://github.com/usebasejump/basejump-next/tree/supabase-bootstrap",
       "start": "Consider installing the Basejump Nextjs starter template"
     }
   ]


### PR DESCRIPTION
I've updated the basejump repo to be closer to what we chatted about and more customizable.  I'd like to keep the Next template an optional addition if users want. They can install it according to the readme instructions.